### PR TITLE
WHERE Clause

### DIFF
--- a/lib/wmic.js
+++ b/lib/wmic.js
@@ -199,10 +199,10 @@ wmic.prototype._wql2wmic = function (query) {
     var args = ['path', path];
 
     if (isWhereExist) {
-        args.push(queryParse[4], 'get', fields.join(','));
-    } else {
-        args.push('get', fields.join(','));
+        var conditions = queryParse[4].replace(/^where\s*/i, '');
+        args.push('where', conditions);
     }
+    args.push('get', fields.join(','));
 
     return args;
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Wrapper around the WMI client. Linux and Windows WMI clients are supported.",
   "main": "index.js",
   "scripts": {
-    "test": "npm test",
+    "test": "node test",
     "install": "node scripts/install.js"
   },
   "repository": {


### PR DESCRIPTION
The parsing of the WQL does not handle the where clause correctly. This is being passed to the `wmic` executable as one command line argument, causing an `INVALID VERB` error (on Windows).

This has been modified to ensure the where clause is added as a separate argument before the conditions so that having a WHERE clause present now works correctly.
